### PR TITLE
feat: add unsafeCache option to speed up recompile times

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -67,6 +67,12 @@ const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
 const emitErrorsAsWarnings = process.env.ESLINT_NO_DEV_ERRORS === 'true';
 const disableESLintPlugin = process.env.DISABLE_ESLINT_PLUGIN === 'true';
 
+// Added by Text-Em-All
+// Cache the resolution of module requests.
+// Allow faster recompile times, though normally not recommended.
+// This was enabled by default on Webpack 4, but turned off in Webpack 5
+const enableUnsafeCache = process.env.ENABLE_UNSAFE_CACHE !== 'false';
+
 const imageInlineSizeLimit = parseInt(
   process.env.IMAGE_INLINE_SIZE_LIMIT || '10000'
 );
@@ -537,6 +543,7 @@ module.exports = function (webpackEnv) {
       ],
     },
     module: {
+      unsafeCache: enableUnsafeCache, // Text-Em-All Web App
       strictExportPresence: true,
       rules: [
         // Handle node_modules packages that contain sourcemaps


### PR DESCRIPTION
# Issue

Recompile times seem slow in cea-desktop. It was actually faster before upgrading `react-scripts`

# Solution

After digging in the depths of several Github issues and threads, I discovered that `unsafeCache` was on by default in Webpack 4, but turned off by default in Webpack 5.

Adding the option back sped up rebuild and hot reload time significantly

# Visuals

Before making any changes, re-compiling and hot reloading a change to a simple label was consistently around 6-8 seconds.

Once I enabled the setting, the time dropped to 3-5 seconds.

Before|After
-----|------
![RecompileBefore](https://user-images.githubusercontent.com/8048702/171977508-dd97cbb3-85d3-4c0f-9522-b78c4ce27845.gif)|![Recompile](https://user-images.githubusercontent.com/8048702/171977531-6e43e409-03da-46d4-ad47-65f2f97a3168.gif)


