### PR TITLE
feat: split vendor and common chunks

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -404,8 +404,8 @@ module.exports = function (webpackEnv) {
           isEnvDevelopment && 'static/js/[name].js', // *** Text-Em-All Web App
       // There are also additional JS chunk files if you use code splitting.
       chunkFilename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].chunk.js'
-        : isEnvDevelopment && 'static/js/[name].chunk.js',
+        ? 'static/js/[id].[contenthash:8].chunk.js'
+        : isEnvDevelopment && 'static/js/[id].[contenthash:8].chunk.js',
       assetModuleFilename: 'static/media/[name].[hash][ext]',
       // webpack uses `publicPath` to determine where the app is being served from.
       // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -485,10 +485,17 @@ module.exports = function (webpackEnv) {
       // Automatically split vendor and commons
       // https://twitter.com/wSokra/status/969633336732905474
       // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
-      // splitChunks: {
-      //   chunks: 'all',
-      //   name: isEnvDevelopment,
-      // },
+      splitChunks: {
+        chunks: 'all',
+        name: isEnvDevelopment ? (module, chunks, cacheGroupKey) => {
+          const moduleFileName = module
+            .identifier()
+            .split('/')
+            .reduceRight((item) => item);
+          const allChunksNames = chunks.map((item) => item.name).join('~');
+          return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;
+        } : false,
+      },
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985
       // https://github.com/facebook/create-react-app/issues/5358


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

# Issue

We used to have an optimization in our Webpack config to split vendor and common chunks. However, when we upgraded CRA and Webpack we had to comment out the optimization because we kept running into this error:

> Multiple assets emit to the same filename

However, now that we've been seeing a slow down in page load times, it's worth investigating a fix

# Solution

Use the [id] instead of the [name] in the chunkFileName. While we're at it, let's also add the hash in the filename. This will guarantee unique fill names. 

Let's also add a custom name function for naming the chunks ([we can use the one from the Webpack docs](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunksname))

# Visuals

This is the build output after running a normal build, then a build with the update Webpack config. Notice the massive change in bundle.[hash].js, onboarding.[hash].js and login.[hash].js:

BEHOLD

Visual|
--------|
![Screen Shot 2022-08-15 at 9 54 57 PM](https://user-images.githubusercontent.com/8048702/184790456-ffd2d7f8-9881-42e5-8215-e9767cf6881e.png)|

For comparison, let's undo the changes and run the normal build again. Now we can see that bundle.[hash].js, onboarding.[hash].js and login.[hash].js have a huge amount of duplicate code added back in, making them almost the same size as each entry point:

Visual|
--------|
![Screen Shot 2022-08-15 at 10 04 22 PM](https://user-images.githubusercontent.com/8048702/184790677-bf5f7da3-9c7c-4646-98e4-e436da29e659.png)|

For a more direct comparison, let's use `yarn analyze`. We can see a ~24% reduction in the "All" size:

Before|After
-----|----
![Screen Shot 2022-08-15 at 10 28 12 PM](https://user-images.githubusercontent.com/8048702/184792031-acd6dcc9-d130-4dd8-9e94-4999b40193a8.png)|![Screen Shot 2022-08-15 at 10 25 49 PM](https://user-images.githubusercontent.com/8048702/184792047-56960ae7-b2fc-4642-8f6e-dc47e932e674.png)


# Test Cases

The easiest way to test this is to copy the contents of the modified file into `client/node_modules/tea-react-scripts/config/webpack.config.js`

You can now run `yarn start` and `yarn nf-build:client`, which will use this new code.

Alternatively:
- Update your client/package.json file to ` "tea-react-scripts": "file:../../create-react-app/packages/react-scripts",`
- Run `yarn clean:purge:client && yarn && yarn start`

