### PR TITLE
fix: disable splitChunks optimization in development mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,15 @@ This fork is used to create a customized `react-scripts` package.
 
 ## Publish to npm
 
-0. For now, ask @daveham to take care of this
-1. TODO: Make a process for anyone to update this package
+1. Get access to the callemall organization on npmjs.com. Hai is the admin and can add you.
+1. Run `npm login` and sign in to your account that's in the the organization
+1. Increment the version number in the package.json and make a PR to `master`
+1. Once that's merged, checkout `master` and pull the latest
+1. Run `cd packages/react-scripts`
+1. You may have to run `nvm use 14`
+1. Run `yarn` to install dependencies
+1. Now run `npm publish`
+1. Make a PR to cea-desktop with the updated version on `tea-react-scripts`
 
 ---
 

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -488,20 +488,13 @@ module.exports = function (webpackEnv) {
       // https://twitter.com/wSokra/status/969633336732905474
       // https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366
       splitChunks: {
-        chunks: 'all',
-        name: isEnvDevelopment
-          ? // Copied directly from Webpack docs
-            // https://webpack.js.org/plugins/split-chunks-plugin/#splitchunksname
-            (module, chunks, cacheGroupKey) => {
-              const moduleFileName = module
-                .identifier()
-                .split('/')
-                .reduceRight(item => item);
-              const allChunksNames = chunks.map(item => item.name).join('~');
-              return `${cacheGroupKey}-${allChunksNames}-${moduleFileName}`;
-            }
-          : // false is the recommend value for production since it will keep the same names
-            false,
+        // use default 'async' value in development.
+        // use 'all' in production to split vendor and common chunks
+        chunks: isEnvDevelopment ? 'async' : 'all',
+        name: false,
+        // Previous values
+        //   chunks: 'all',
+        //   name: isEnvDevelopment,
       },
       // Keep the runtime chunk separated to enable long term caching
       // https://twitter.com/wSokra/status/969679223278505985

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea-react-scripts",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Used by Text-Em-All, Custom Configuration and scripts for Create React App, based on version 5.0.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->
# Issue

My previous PR broke something in the development build. While starting development with `yarn start` normally takes ~7 minutes, this change was causing the process to run for well over 30 minutes

# Solution

Disable the optimization in development only.

It seems to work fine for a production build, so we can still get the benefits of the change.

I also noticed that we never documented the process for releasing a new version. I went ahead and put together a quick guide that we can refer to in the future.

# Test Cases

1. Checkout https://github.com/callemall/cea-desktop/pull/8206
1. Open `client/node_modules/tea-react-scripts/config/webpack.config.js` in cea-desktop
1. Copy over the changes from this PR
1. Run `yarn start`
1. Verify that it starts within a few minutes (should be less than 10, may vary by machine)