### PR TITLE
fix(react-scripts): add fallback for node url package for use with TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This fork is used to create a customized `react-scripts` package.
 
 ---
 
-# Create React App [![Build Status](https://dev.azure.com/facebook/create-react-app/_apis/build/status/facebook.create-react-app?branchName=master)](https://dev.azure.com/facebook/create-react-app/_build/latest?definitionId=1&branchName=master) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/master/CONTRIBUTING.md)
+## Create React App [![Build Status](https://dev.azure.com/facebook/create-react-app/_apis/build/status/facebook.create-react-app?branchName=master)](https://dev.azure.com/facebook/create-react-app/_build/latest?definitionId=1&branchName=master) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://github.com/facebook/create-react-app/blob/master/CONTRIBUTING.md)
 
 <img alt="Logo" align="right" src="https://create-react-app.dev/img/logo.svg" width="20%" />
 
@@ -133,7 +133,7 @@ _[`yarn create <starter-kit-package>`](https://yarnpkg.com/lang/en/docs/cli/crea
 It will create a directory called `my-app` inside the current folder.<br>
 Inside that directory, it will generate the initial project structure and install the transitive dependencies:
 
-```
+```sh
 my-app
 ├── README.md
 ├── node_modules

--- a/packages/react-scripts/README.md
+++ b/packages/react-scripts/README.md
@@ -1,8 +1,8 @@
-## Note: This is part of a fork of `Create React App` used by Text-Em-All
+# Note: This is part of a fork of `Create React App` used by Text-Em-All
 
 This is a customized react-scripts package.
 
-# react-scripts
+## react-scripts
 
 This package includes scripts and configuration used by [Create React App](https://github.com/facebook/create-react-app).<br>
 Please refer to its documentation:

--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -506,6 +506,11 @@ module.exports = function (webpackEnv) {
       // runtimeChunk: 'single', // *** Text-Em-All Web App, was true,
     },
     resolve: {
+      // Webpack v5 stopped shipping with polyfills for node.js core modules.
+      fallback: {
+        url: require.resolve('url/'),
+      },
+
       // This allows you to set a fallback for where webpack should look for modules.
       // We placed these paths second because we want `node_modules` to "win"
       // if there are any conflicts. This matches Node resolution mechanism.

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -71,6 +71,7 @@
     "style-loader": "^3.3.1",
     "tailwindcss": "^3.0.2",
     "terser-webpack-plugin": "^5.2.5",
+    "url": "^0.11.0",
     "webpack": "^5.64.4",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-dev-server": "^4.6.0",


### PR DESCRIPTION
### Completes [Trello Story](https://trello.com/c/l6yDRJUa)

--------------
# The issue

Add fallback for our custom Webpack scripts to work with TypeScript

# The solution

- Add a `fallback` section to the webpack config
- Add `url` to the `package.json` so the client app that consumes this package will install that new package.

# Visuals

When | image
----- | -----
Before | <img width="1259" alt="Screen Shot 2022-12-12 at 12 30 39 PM" src="https://user-images.githubusercontent.com/11624407/207126115-2c52b51f-bb5c-437f-be0b-29623764542c.png">
After - dev | <img width="1433" alt="image" src="https://user-images.githubusercontent.com/11624407/207126372-2c28d461-3a1b-433c-a363-bded6da25f60.png">
After - prod | <img width="1433" alt="image" src="https://user-images.githubusercontent.com/11624407/207126291-80a6b389-29b7-42f5-9b17-280b5256f593.png">

# Test cases

1. Get this code in your local clone of the `tea-create-react-app` repo
    - You might have named yours `create-react-app`. 👀 
1. For the local R2D2 project, go to the `development` branch. Get it up to date.
2. In `client/package.json`, replace the `tea-react-scripts` line with this, pointing to your local version (naming might be different for you):
  
```json
"tea-react-scripts": "file:../../tea-create-react-app/packages/react-scripts",
```
4. Run `yarn` and take a 5-8 minute break. 😅 
5. After that is done, run both the `dev` and `prod` builds. Check the normal app and also sign in with `humberto_onboarding` to make sure that chunk is working:
    - `yarn start`
    - `yarn test:server`

Once this is good to go, I have no clue how to publish it. I'm currently locked out of `npm`, awaiting contact from them to reinstate my credentials. 
