### PR TITLE
chore: bump tea-react-scripts version to 1.0.16

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea-react-scripts",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Used by Text-Em-All, Custom Configuration and scripts for Create React App, based on version 5.0.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Forgot to bump the version on #14

![homer_bushes](https://user-images.githubusercontent.com/11624407/207138151-808ad029-55e7-4978-bd4c-e1fb22ab9099.gif)
