### PR TITLE
fix(webpack): increase typescript memory limit

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -787,6 +787,7 @@ module.exports = function (webpackEnv) {
               syntactic: true,
             },
             mode: 'write-references',
+            memoryLimit: 4096,
             // profile: true,
           },
           issue: {

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tea-react-scripts",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Used by Text-Em-All, Custom Configuration and scripts for Create React App, based on version 5.0.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://trello.com/c/iu73Ym6U

<!--
Thank you for sending the PR!

If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots!

Happy contributing!
-->

## Issue

I'm still seeing crashing when running the web app locally. Looking closely at the error message, they suggest updating the memory limit on ForkTsCheckerWebpackPlugin


<img width="1172" height="268" alt="Screenshot 2025-07-16 at 11 06 13 AM" src="https://github.com/user-attachments/assets/949f4d4d-d717-4369-befd-a9859eb7d3ce" />

## Solution

Looking at the docs for [ForkTsCheckerWebpackPlugin](https://www.npmjs.com/package/fork-ts-checker-webpack-plugin), we see that the default limit is 2GB. Let's bump it to 4GB

<img width="883" height="300" alt="Screenshot 2025-07-16 at 11 20 25 AM" src="https://github.com/user-attachments/assets/4a784d83-9743-42c1-8f52-bb84d0ca88d3" />

## Testing

I was able to consistently reproduce the crash in cea-desktop with these steps:
- Checkout `main` and run `yarn start`
- Checkout an old version `git checkout 1.504.0`
- Wait several seconds and observe the crash

We can verify that this fix works by:
- In cea-desktop client, open node_modules/tea-react-scripts/config/webpack.config.js
- Apply this change to that file (add the line from this PR)
- Repeat the above test of checking out main and switching to an old branch
- Verify that the crash no longer occurs

Note that you should still expect to see unrelated compilation errors due to the significant difference between the two versions of the code base. However, the crash should not occur.

